### PR TITLE
Changed Create trap key section

### DIFF
--- a/mib2zabbix.pl
+++ b/mib2zabbix.pl
@@ -538,8 +538,8 @@ sub node_to_trapitem {
     
     # Create trap key
     my $oid = $node->{ objectID };
-    $oid =~ s/\./\\./g;
-    $item->{ key } = "snmptrap[\"\\s$oid\\s\"]";
+    $oid =~ s/\.1\.3\.6\.1\.4\.1/SNMPv2\-SMI\:\:enterprises/g; # Replace .1.3.6.1.4.1 with SNMPv2-SMI::enterprises
+    $item->{ key } = "snmptrap[\"$oid\"]";
     
     # Parse item desciption
     my $desc = '';


### PR DESCRIPTION
$oid =~ s/\./\\./g;  # replaces a . with \. However when receiving trap alerts it comes with partially translated trapoid
Eg: 
  SNMPv2-MIB::snmpTrapOID.0      type=6  value=OID: SNMPv2-SMI::enterprises.789.0.13

It does not match with full oid created in the code.

Also $item->{ key } = "snmptrap[\"\\s$oid\\s\"]";  # surrounds with the oid with \s. When I checked it with http://www.rexv.org/ under posix regex none of those matched. Therefore item key had to change. 
$item->{ key } = "snmptrap[\"$oid\"]";
 
Please note that this was tested only on NETAPP-MIB