### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ tree in a SNMP MIB file.
 Install from GitHub:
 
     # install prerequisites on Ubuntu: 
-    apt-get install perl libxml-simple-perl libsnmp-perl
+    apt-get install perl libxml-simple-perl libsnmp-perl libtimedate-perl
 
     # install prerequisites on RHEL family:
     yum install "perl(SNMP)" "perl(XML::Simple)"


### PR DESCRIPTION
Can't locate Date/Format.pm in @INC (you may need to install the Date::Format module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /home/appliance/bin/mib2zabbix line 81.