### PR TITLE
Allow Zabbix time spec instead of just seconds for check-delay and disc-delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ tree in a SNMP MIB file.
 
     Zabbix item configuration
 
-        --check-delay=SECONDS       check interval in seconds (default: 60)
-        --disc-delay=SECONDS        discovery interval in seconds (default: 3600)
+        --check-delay=TIME          check interval in Zabbix time units (default: 1m)
+        --disc-delay=TIME           discovery interval in Zabbix time units (default: 1h)
         --history=DAYS              history retention in days (default: 7)
         --trends=DAYS               trends retention in days (default: 365)
         

--- a/mib2zabbix.pl
+++ b/mib2zabbix.pl
@@ -173,8 +173,8 @@ my $snmpv3_sec_protocol_map = {
 
 # Default command line options
 my $opts =  {
-    delay               => 60,              # 1 minute check interval
-    disc_delay          => 3600,            # Hourly discovery
+    delay               => '1m',                # 1 minute check interval
+    disc_delay          => '1h',            # Hourly discovery
     enableitems         => 0,               # Disable items
     group               => 'Templates',
     history             => 7,
@@ -222,8 +222,8 @@ GetOptions(
     'x|privacy=s'           => \$opts->{ v3sec_protocol },  # SNMPv3 Privacy protocol
     'X|privpass=s'          => \$opts->{ v2sec_pass},       # SNMPv3 Privacy passphrase
 
-    'check-delay=i'         => \$opts->{ delay },           # Update interval in seconds
-    'disc-delay=i'          => \$opts->{ disc_delay },      # Update interval in seconds
+    'check-delay=s'         => \$opts->{ delay },           # Update interval in seconds
+    'disc-delay=s'          => \$opts->{ disc_delay },      # Update interval in seconds
     'history=i'             => \$opts->{ history },         # History retention in days
     'trends=i'              => \$opts->{ trends },          # Trends retention in days
 


### PR DESCRIPTION
In Zabbix, the item check interval and discovery intervals can be
specified not just with a number of seconds, but with more convenient
units using time suffixes as well.

See https://www.zabbix.com/documentation/current/en/manual/appendix/suffixes
for a list of supported suffixes.

By allowing strings as arguments to --check-delay and --disc-delay,
these interval specifications can be used.

No checking for correct syntax (i.e. valid time suffixes) is done; if
required, this can be added to the code as well.