### PR TITLE
Make ordering of mappings and application stable

### DIFF
--- a/mib2zabbix.pl
+++ b/mib2zabbix.pl
@@ -510,7 +510,7 @@ sub node_to_item {
 
         # add template value map
         $valuemaps->{ $map_name }->{ 'mappings' } = [];
-        foreach(keys %{ $node->{ enums } }) {
+        foreach(sort keys %{ $node->{ enums } }) {
             push(@{ $valuemaps->{ $map_name }->{ 'mappings' } }, {
                 'value'     => $node->{ enums }->{ $_ },
                 'newvalue'  => $_
@@ -876,7 +876,7 @@ if (!$oid_root || $oid_root->{ objectID } ne $opts->{ oid }) {
     build_template($template, $oid_root, 0);
 
     # Convert applications hash to array
-    @{ $template->{ applications } } = map { { name => $_ } } keys %{ $template->{ apptags } };
+    @{ $template->{ applications } } = map { { name => $_ } } sort keys %{ $template->{ apptags } };
     delete($template->{ apptags });
 
     # Build XML document


### PR DESCRIPTION
Perl 5.8.1 added hash randomisation (see
https://metacpan.org/release/JHI/perl-5.8.1/view/pod/perldelta.pod#Hash-Randomisation).

The effect is that multiple invocations of `keys %hash` return the hash keys in
different ordering, even between separate runs of the script with the same
inputs.

As a result, running the script multiple times, yielded non-identical XML
output, since the order of the mappings and application lists is different
every time.

By first sorting the hash keys for the mapping and application hashes before
iterating over them, multiple runs of the script with the same inputs result in
identical output.